### PR TITLE
Return null on unsupported history and data download requests

### DIFF
--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageDataQueueHandlerTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageDataQueueHandlerTests.cs
@@ -22,6 +22,7 @@ using QuantConnect.Logging;
 using Microsoft.CodeAnalysis;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
+using QuantConnect.Tests;
 
 namespace QuantConnect.CoinbaseBrokerage.Tests
 {
@@ -39,6 +40,8 @@ namespace QuantConnect.CoinbaseBrokerage.Tests
         {
             get
             {
+                TestGlobals.Initialize();
+
                 yield return new TestCaseData(BTCUSDC, Resolution.Tick);
                 yield return new TestCaseData(BTCUSDC, Resolution.Second);
                 yield return new TestCaseData(BTCUSDC, Resolution.Minute);

--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
@@ -32,7 +32,7 @@ namespace QuantConnect.CoinbaseBrokerage.Tests
     public class CoinbaseBrokerageHistoryProviderTests
     {
         [Test, TestCaseSource(nameof(TestParameters))]
-        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool shouldBeEmpty, bool unsupported)
+        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool unsupported)
         {
             var brokerage = new CoinbaseBrokerage(
                 Config.Get("coinbase-url", "wss://advanced-trade-ws.coinbase.com"),
@@ -65,12 +65,7 @@ namespace QuantConnect.CoinbaseBrokerage.Tests
                 return;
             }
 
-            if (shouldBeEmpty)
-            {
-                Assert.IsEmpty(history);
-                return;
-            }
-
+            Assert.IsNotNull(history);
             Assert.IsNotEmpty(history);
 
             foreach (var bar in history.Cast<TradeBar>())
@@ -90,33 +85,33 @@ namespace QuantConnect.CoinbaseBrokerage.Tests
                 var BTCUSDC = Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.Coinbase);
 
                 // valid parameters
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, TimeSpan.FromDays(5), false, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, Time.OneHour, false, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, Time.OneDay, false, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, TimeSpan.FromDays(5), false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, Time.OneHour, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, Time.OneDay, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false);
 
-                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, Time.OneHour, false, false);
-                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, Time.OneDay, false, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, Time.OneHour, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, Time.OneDay, false);
 
-                // invalid period, no error, empty result
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true, false);
+                // invalid period
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true);
 
                 // quote tick type, null result
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, TimeSpan.FromDays(15), false, true);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, TimeSpan.FromDays(15), false, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, TimeSpan.FromDays(15), true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, TimeSpan.FromDays(15), true);
 
                 // invalid resolution, null result
-                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), false, true);
-                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, Time.OneMinute, false, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), true);
+                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, Time.OneMinute, true);
 
                 // invalid symbol, null result
-                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, true);
+                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
 
                 // invalid security type, null result
-                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, true);
+                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
 
                 // invalid market, null result
-                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, true);
+                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
             }
         }
     }

--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
@@ -25,7 +25,6 @@ using QuantConnect.Data.Market;
 using System.Collections.Generic;
 using QuantConnect.Configuration;
 using QuantConnect.Lean.Engine.DataFeeds;
-using QuantConnect.Lean.Engine.HistoricalData;
 
 namespace QuantConnect.CoinbaseBrokerage.Tests
 {
@@ -33,60 +32,53 @@ namespace QuantConnect.CoinbaseBrokerage.Tests
     public class CoinbaseBrokerageHistoryProviderTests
     {
         [Test, TestCaseSource(nameof(TestParameters))]
-        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool shouldBeEmpty)
+        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool shouldBeEmpty, bool unsupported)
         {
-            var aggregator = new AggregationManager();
-
             var brokerage = new CoinbaseBrokerage(
                 Config.Get("coinbase-url", "wss://advanced-trade-ws.coinbase.com"),
                 Config.Get("coinbase-api-key"),
                 Config.Get("coinbase-api-secret"),
                 Config.Get("coinbase-rest-api", "https://api.coinbase.com"),
                 null,
-                aggregator,
+                new AggregationManager(),
                 null);
 
-            var historyProvider = new BrokerageHistoryProvider();
-            historyProvider.SetBrokerage(brokerage);
-            historyProvider.Initialize(new HistoryProviderInitializeParameters(null, null, null, null, null, null, null, false, new DataPermissionManager(), null));
-
             var now = DateTime.UtcNow;
+            var request = new HistoryRequest(now.Add(-period),
+                now,
+                typeof(TradeBar),
+                symbol,
+                resolution,
+                SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
+                DateTimeZone.Utc,
+                resolution,
+                false,
+                false,
+                DataNormalizationMode.Adjusted,
+                tickType);
 
-            var requests = new[]
+            var history = brokerage.GetHistory(request)?.ToList();
+
+            if (unsupported)
             {
-                new HistoryRequest(now.Add(-period),
-                    now,
-                    typeof(TradeBar),
-                    symbol,
-                    resolution,
-                    SecurityExchangeHours.AlwaysOpen(TimeZones.Utc),
-                    DateTimeZone.Utc,
-                    resolution,
-                    false,
-                    false,
-                    DataNormalizationMode.Adjusted,
-                    tickType)
-            };
-
-            var history = historyProvider.GetHistory(requests, TimeZones.Utc).ToList();
-
-            foreach (var slice in history)
-            {
-                var bar = slice.Bars[symbol];
-
-                Log.Trace($"{bar.Time}: {bar.Symbol} - O={bar.Open}, H={bar.High}, L={bar.Low}, C={bar.Close}, V={bar.Volume}");
+                Assert.IsNull(history);
+                return;
             }
 
             if (shouldBeEmpty)
             {
-                Assert.IsTrue(history.Count == 0);
-            }
-            else
-            {
-                Assert.IsTrue(history.Count > 0);
+                Assert.IsEmpty(history);
+                return;
             }
 
-            Log.Trace("Data points retrieved: " + historyProvider.DataPointCount);
+            Assert.IsNotEmpty(history);
+
+            foreach (var bar in history.Cast<TradeBar>())
+            {
+                Log.Trace($"{bar.Time}: {bar.Symbol} - O={bar.Open}, H={bar.High}, L={bar.Low}, C={bar.Close}, V={bar.Volume}");
+            }
+
+            Log.Trace("Data points retrieved: " + history.Count);
         }
 
         private static IEnumerable<TestCaseData> TestParameters
@@ -98,29 +90,33 @@ namespace QuantConnect.CoinbaseBrokerage.Tests
                 var BTCUSDC = Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.Coinbase);
 
                 // valid parameters
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, TimeSpan.FromDays(5), false);
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, Time.OneHour, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, Time.OneDay, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, TimeSpan.FromDays(5), false, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, Time.OneHour, false, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, Time.OneDay, false, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, false);
 
-                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, Time.OneHour, false);
-                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, Time.OneDay, false);
-
-                // quote tick type, no error, empty result
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, TimeSpan.FromDays(15), true);
-
-                // invalid resolution, no error, empty result
-                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), true);
-                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, Time.OneMinute, true);
+                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, Time.OneHour, false, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, Time.OneDay, false, false);
 
                 // invalid period, no error, empty result
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true, false);
 
-                // invalid symbol, no error, empty result
-                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
+                // quote tick type, null result
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, TimeSpan.FromDays(15), false, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, TimeSpan.FromDays(15), false, true);
 
-                // invalid security type, no error, empty result
-                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
+                // invalid resolution, null result
+                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), false, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, Time.OneMinute, false, true);
+
+                // invalid symbol, null result
+                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, true);
+
+                // invalid security type, null result
+                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, true);
+
+                // invalid market, null result
+                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false, true);
             }
         }
     }

--- a/QuantConnect.CoinbaseBrokerage.ToolBox/CoinbaseDownloader.cs
+++ b/QuantConnect.CoinbaseBrokerage.ToolBox/CoinbaseDownloader.cs
@@ -43,13 +43,8 @@ namespace QuantConnect.CoinbaseBrokerage.ToolBox
             var endUtc = dataDownloaderGetParameters.EndUtc;
             var tickType = dataDownloaderGetParameters.TickType;
 
-            if (tickType != TickType.Trade)
-            {
-                return Enumerable.Empty<BaseData>();
-            }
-
-            var type = default(Type);
-            if(resolution == Resolution.Tick)
+            Type type;
+            if (resolution == Resolution.Tick)
             {
                 type = typeof(Tick);
             }

--- a/QuantConnect.CoinbaseBrokerage.ToolBox/CoinbaseDownloader.cs
+++ b/QuantConnect.CoinbaseBrokerage.ToolBox/CoinbaseDownloader.cs
@@ -72,8 +72,7 @@ namespace QuantConnect.CoinbaseBrokerage.ToolBox
                 tickType);
 
             var brokerage = CreateBrokerage();
-            var data = brokerage.GetHistory(historyRequest);
-            return data;
+            return brokerage.GetHistory(historyRequest);
         }
 
         /// <summary>

--- a/QuantConnect.CoinbaseBrokerage.ToolBox/CoinbaseDownloaderProgram.cs
+++ b/QuantConnect.CoinbaseBrokerage.ToolBox/CoinbaseDownloaderProgram.cs
@@ -54,6 +54,10 @@ namespace QuantConnect.CoinbaseBrokerage.ToolBox
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Crypto, market);
                     var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, castResolution, fromDate, toDate));
+                    if (data == null)
+                    {
+                        continue;
+                    }
 
                     // Save the data
                     var writer = new LeanDataWriter(castResolution, symbolObject, dataDirectory, TickType.Trade);

--- a/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.HistoryProvider.cs
+++ b/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.HistoryProvider.cs
@@ -20,6 +20,7 @@ using QuantConnect.Brokerages;
 using QuantConnect.Data.Market;
 using System.Collections.Generic;
 using QuantConnect.CoinbaseBrokerage.Models.Enums;
+using System.Linq;
 
 namespace QuantConnect.CoinbaseBrokerage
 {
@@ -31,7 +32,9 @@ namespace QuantConnect.CoinbaseBrokerage
         /// <summary>
         /// Prevent spam to external source
         /// </summary>
-        private bool _loggedCoinbaseSupportsOnlyTradeBars = false;
+        private bool _loggedCoinbaseSupportsOnlyTradeBars;
+        private bool _loggedUnsupportedAssetForHistory;
+        private bool _loggedUnsupportedResolutionForHistory;
 
         /// <summary>
         /// Gets the history for the requested security
@@ -40,6 +43,16 @@ namespace QuantConnect.CoinbaseBrokerage
         /// <returns>An enumerable of bars covering the span specified in the request</returns>
         public override IEnumerable<BaseData> GetHistory(HistoryRequest request)
         {
+            if (!CanSubscribe(request.Symbol))
+            {
+                if (!_loggedUnsupportedAssetForHistory)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "UnsupportedAsset",
+                        $"Unsupported asset: {request.Symbol.Value}, no history returned"));
+                }
+                return null;
+            }
+
             // Coinbase API only allows us to support history requests for TickType.Trade
             if (request.TickType != TickType.Trade)
             {
@@ -49,50 +62,37 @@ namespace QuantConnect.CoinbaseBrokerage
                     _algorithm?.Debug($"Warning.{nameof(CoinbaseBrokerage)}: history provider only supports trade information, does not support quotes.");
                     Log.Error($"{nameof(CoinbaseBrokerage)}.{nameof(GetHistory)}(): only supports TradeBars");
                 }
-                yield break;
+                return null;
             }
 
-            if (!_symbolMapper.IsKnownLeanSymbol(request.Symbol))
+            if (request.Resolution == Resolution.Tick || request.Resolution == Resolution.Second)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSymbol",
-                    $"Unknown symbol: {request.Symbol.Value}, no history returned"));
-                yield break;
-            }
-
-            if (request.Symbol.SecurityType != SecurityType.Crypto)
-            {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSecurityType",
-                    $"{request.Symbol.SecurityType} security type not supported, no history returned"));
-                yield break;
+                if (!_loggedUnsupportedResolutionForHistory)
+                {
+                    _loggedUnsupportedResolutionForHistory = true;
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidResolution",
+                        $"{request.Resolution} resolution not supported, no history returned"));
+                }
+                return null;
             }
 
             if (request.StartTimeUtc >= request.EndTimeUtc)
             {
                 OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidDateRange",
                     "The history request start date must precede the end date, no history returned"));
-                yield break;
-            }
-
-            if (request.Resolution == Resolution.Tick || request.Resolution == Resolution.Second)
-            {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidResolution",
-                    $"{request.Resolution} resolution not supported, no history returned"));
-                yield break;
+                return Enumerable.Empty<BaseData>();
             }
 
             Log.Debug($"{nameof(CoinbaseBrokerage)}.{nameof(GetHistory)}: Submitting request: {request.Symbol.Value}: {request.Resolution} {request.StartTimeUtc} UTC -> {request.EndTimeUtc} UTC");
 
-            foreach (var tradeBar in GetHistoryFromCandles(request))
-            {
-                yield return tradeBar;
-            }
+            return GetHistoryFromCandles(request);
         }
 
         /// <summary>
         /// Returns TradeBars from Coinbase candles (only for Minute/Hour/Daily resolutions)
         /// </summary>
         /// <param name="request">The history request instance</param>
-        private IEnumerable<TradeBar> GetHistoryFromCandles(HistoryRequest request)
+        private IEnumerable<BaseData> GetHistoryFromCandles(HistoryRequest request)
         {
             var productId = _symbolMapper.GetBrokerageSymbol(request.Symbol);
             var resolutionTimeSpan = request.Resolution.ToTimeSpan();
@@ -107,6 +107,7 @@ namespace QuantConnect.CoinbaseBrokerage
                 Resolution.Minute => CandleGranularity.OneMinute,
                 Resolution.Hour => CandleGranularity.OneHour,
                 Resolution.Daily => CandleGranularity.OneDay,
+                // This should never happen if the right checks are in place in the caller
                 _ => throw new NotSupportedException($"The resolution {request.Resolution} is not supported.")
             };
 

--- a/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.cs
+++ b/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.cs
@@ -370,7 +370,8 @@ namespace QuantConnect.CoinbaseBrokerage
         {
             return !symbol.Value.Contains("UNIVERSE") &&
                 symbol.SecurityType == SecurityType.Crypto &&
-                symbol.ID.Market == MarketName;
+                symbol.ID.Market == MarketName &&
+                _symbolMapper.IsKnownLeanSymbol(symbol);
         }
 
         #endregion


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
