### PR TITLE
Refactor: Improve `ParseKey`

### DIFF
--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseApiTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseApiTests.cs
@@ -44,9 +44,9 @@ namespace QuantConnect.Brokerages.Coinbase.Tests
             CoinbaseApi = CreateCoinbaseApi(name, priavteKey);
         }
 
-        [TestCase("", "", typeof(ArgumentOutOfRangeException))]
-        [TestCase("organizations/2c7dhs-a3a3-4acf-aa0c-f68584f34c37/apiKeys/41090ffa-asd2-4040-815f-afaf63747e35", "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPcJGfXYEdLQi0iFj1xvGfPwuRNoeddwuKS4xL2NrlGWpoAoGCCqGSM49\nAwEHoUQDQgAEclN+asd/EhJ3UjOWkHmP/iqGBv5NkNJ75bUq\nVgxS4aU3/djHiIuSf27QasdOFIDGJLmOn7YiQ==\n-----END EC PRIVATE KEY-----\n", typeof(CryptographicException))]
-        [TestCase("organizations/2c7dhs-a3a3-4acf-aa0c-f68584f34c37/apiKeys/41090ffa-asd2-4040-815f-afaf63747e35", "MHcCAQEEIPcJGfXYEdLQi0iFj1xvGfPwuRNoeddwuKS4xL2NrlGWpoAoGCCqGSM49\nAwEHoUQDQgAEclN+asd/EhJ3UjOWkHmP/iqGBv5NkNJ75bUq\nVgxS4aU3/djHiIuSf27QasdOFIDGJLmOn7YiQ==", typeof(CryptographicException))]
+        [TestCase("", "", typeof(InvalidOperationException))]
+        [TestCase("organizations/2c7dhs-a3a3-4acf-aa0c-f68584f34c37/apiKeys/41090ffa-asd2-4040-815f-afaf63747e35", "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPcJGfXYEdLQi0iFj1xvGfPwuRNoeddwuKS4xL2NrlGWpoAoGCCqGSM49\nAwEHoUQDQgAEclN+asd/EhJ3UjOWkHmP/iqGBv5NkNJ75bUq\nVgxS4aU3/djHiIuSf27QasdOFIDGJLmOn7YiQ==\n-----END EC PRIVATE KEY-----\n", typeof(InvalidOperationException))]
+        [TestCase("organizations/2c7dhs-a3a3-4acf-aa0c-f68584f34c37/apiKeys/41090ffa-asd2-4040-815f-afaf63747e35", "MHcCAQEEIPcJGfXYEdLQi0iFj1xvGfPwuRNoeddwuKS4xL2NrlGWpoAoGCCqGSM49\nAwEHoUQDQgAEclN+asd/EhJ3UjOWkHmP/iqGBv5NkNJ75bUq\nVgxS4aU3/djHiIuSf27QasdOFIDGJLmOn7YiQ==", typeof(InvalidOperationException))]
         public void InvalidAuthenticationCredentialsShouldThrowException(string name, string privateKey, Type expectedException)
         {
             try

--- a/QuantConnect.CoinbaseBrokerage/Api/CoinbaseApiClient.cs
+++ b/QuantConnect.CoinbaseBrokerage/Api/CoinbaseApiClient.cs
@@ -224,12 +224,11 @@ public class CoinbaseApiClient : IDisposable
     internal string ParseKey(string key)
     {
         var keyLines = key
-            .Replace("-", "")
-            .Replace("BEGIN EC PRIVATE KEY", "")
-            .Replace("END EC PRIVATE KEY", "")
-            .Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
+            .Replace("-----BEGIN EC PRIVATE KEY-----", string.Empty)
+            .Replace("-----END EC PRIVATE KEY-----", string.Empty)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
-        return string.Join("", keyLines);
+        return string.Join(string.Empty, keyLines);
     }
 
     /// <summary>

--- a/QuantConnect.CoinbaseBrokerage/Api/CoinbaseApiClient.cs
+++ b/QuantConnect.CoinbaseBrokerage/Api/CoinbaseApiClient.cs
@@ -114,8 +114,9 @@ public class CoinbaseApiClient : IDisposable
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"{nameof(CoinbaseApiClient)}.{nameof(CreateECDsaByPrivateKey)}: Failed to create ECDsa from the provided private key." +
-                $"Full Key: '{userInputPrivateKey}'. Parsed Key: '{parsedKey}'. Error: {ex.Message}",
+            throw new InvalidOperationException($"{nameof(CoinbaseApiClient)}.{nameof(CreateECDsaByPrivateKey)}: Failed to create ECDsa from the provided private key.\n" +
+            "Please refer to the documentation for the correct key format: " +
+            $"https://www.quantconnect.com/docs/v2/cloud-platform/live-trading/brokerages/coinbase#02-Account-Types\n\n Error: {ex.Message}",
             ex);
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Handle Parsing user PEM key with the great exception message.
- we have replace `-----BEGIN EC PRIVATE KEY-----` and `-----END EC PRIVATE KEY-----` on `empty.string`.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #26 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Decrease the amount of bugs and increase user experience with the great exception message.

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TestCases
1. with `-----BEGIN EC PRIVATE KEY-----` && `-----END EC PRIVATE KEY-----` (without `\n`)
2. with `-----BEGIN EC PRIVATE KEY-----` && `-----END EC PRIVATE KEY-----` (with `\n`)
3. only with '\n'
4. only PEM key without `BEGIN` && `END`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
