### PR TITLE
Fix empty history when start date predates asset listing

### DIFF
--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
@@ -31,7 +31,7 @@ namespace QuantConnect.Brokerages.Coinbase.Tests
     public class CoinbaseBrokerageHistoryProviderTests
     {
         [Test, TestCaseSource(nameof(TestParameters))]
-        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, TimeSpan period, bool unsupported)
+        public void GetsHistory(Symbol symbol, Resolution resolution, TickType tickType, DateTime startUtc, DateTime endUtc, bool unsupported)
         {
             var brokerage = new CoinbaseBrokerage(
                 Config.Get("coinbase-url", "wss://advanced-trade-ws.coinbase.com"),
@@ -41,9 +41,8 @@ namespace QuantConnect.Brokerages.Coinbase.Tests
                 null,
                 null);
 
-            var now = DateTime.UtcNow;
-            var request = new HistoryRequest(now.Add(-period),
-                now,
+            var request = new HistoryRequest(startUtc,
+                endUtc,
                 typeof(TradeBar),
                 symbol,
                 resolution,
@@ -79,41 +78,45 @@ namespace QuantConnect.Brokerages.Coinbase.Tests
             get
             {
                 TestGlobals.Initialize();
+                var now = DateTime.UtcNow;
                 var BTCUSD = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase);
                 var BTCUSDC = Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.Coinbase);
+                var ETHUSD = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Coinbase);
 
                 // valid parameters
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, TimeSpan.FromDays(5), false);
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, Time.OneHour, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, Time.OneDay, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, now.AddDays(-5), now, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, now.Add(-Time.OneHour), now, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, now.Add(-Time.OneDay), now, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, now.AddDays(-15), now, false);
 
-                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, Time.OneHour, false);
-                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, Time.OneDay, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, now.Add(-Time.OneHour), now, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, now.Add(-Time.OneDay), now, false);
 
-                // start date before asset existed on Coinbase (ETHUSD listed May 2016) - should still return available data
-                var ETHUSD = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Coinbase);
-                yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(3800), false);
+                // start before ETH listing (May 18 2016), listing falls within the first 300-day batch
+                yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, new DateTime(2016, 1, 1), new DateTime(2017, 1, 1), false);
+
+                // start well before listing, should return data from the listing date onwards
+                yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, new DateTime(2010, 1, 1), new DateTime(2017, 1, 1), false);
 
                 // invalid period
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, now, now.AddDays(-15), true);
 
                 // quote tick type, null result
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, TimeSpan.FromDays(15), true);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, TimeSpan.FromDays(15), true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, now.AddDays(-15), now, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, now.AddDays(-15), now, true);
 
                 // invalid resolution, null result
-                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, TimeSpan.FromSeconds(15), true);
-                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, Time.OneMinute, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, now.AddSeconds(-15), now, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, now.Add(-Time.OneMinute), now, true);
 
                 // invalid symbol, null result
-                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
+                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, now.AddDays(-15), now, true);
 
                 // invalid security type, null result
-                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
+                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, now.AddDays(-15), now, true);
 
                 // invalid market, null result
-                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, TimeSpan.FromDays(15), true);
+                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, now.AddDays(-15), now, true);
             }
         }
     }

--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
@@ -91,6 +91,10 @@ namespace QuantConnect.Brokerages.Coinbase.Tests
                 yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, Time.OneHour, false);
                 yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, Time.OneDay, false);
 
+                // start date before asset existed on Coinbase (ETHUSD listed May 2016) - should still return available data
+                var ETHUSD = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Coinbase);
+                yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(3800), false);
+
                 // invalid period
                 yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, TimeSpan.FromDays(-15), true);
 

--- a/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.CoinbaseBrokerage.Tests/CoinbaseBrokerageHistoryProviderTests.cs
@@ -78,45 +78,48 @@ namespace QuantConnect.Brokerages.Coinbase.Tests
             get
             {
                 TestGlobals.Initialize();
-                var now = DateTime.UtcNow;
+                var refDate = new DateTime(2025, 1, 1);
                 var BTCUSD = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase);
                 var BTCUSDC = Symbol.Create("BTCUSDC", SecurityType.Crypto, Market.Coinbase);
                 var ETHUSD = Symbol.Create("ETHUSD", SecurityType.Crypto, Market.Coinbase);
 
                 // valid parameters
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, now.AddDays(-5), now, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, now.Add(-Time.OneHour), now, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, now.Add(-Time.OneDay), now, false);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, now.AddDays(-15), now, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, refDate.AddDays(-5), refDate, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Minute, TickType.Trade, refDate.Add(-Time.OneHour), refDate, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Hour, TickType.Trade, refDate.Add(-Time.OneDay), refDate, false);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, refDate.AddDays(-15), refDate, false);
 
-                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, now.Add(-Time.OneHour), now, false);
-                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, now.Add(-Time.OneDay), now, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Minute, TickType.Trade, refDate.Add(-Time.OneHour), refDate, false);
+                yield return new TestCaseData(BTCUSDC, Resolution.Hour, TickType.Trade, refDate.Add(-Time.OneDay), refDate, false);
 
                 // start before ETH listing (May 18 2016), listing falls within the first 300-day batch
                 yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, new DateTime(2016, 1, 1), new DateTime(2017, 1, 1), false);
+
+                // start just before the 300 day window that includes the listing: first batch returns empty, second batch finds data
+                yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, new DateTime(2015, 7, 20), new DateTime(2025, 9, 1), false);
 
                 // start well before listing, should return data from the listing date onwards
                 yield return new TestCaseData(ETHUSD, Resolution.Daily, TickType.Trade, new DateTime(2010, 1, 1), new DateTime(2017, 1, 1), false);
 
                 // invalid period
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, now, now.AddDays(-15), true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Trade, refDate, refDate.AddDays(-15), true);
 
                 // quote tick type, null result
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, now.AddDays(-15), now, true);
-                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, now.AddDays(-15), now, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.Quote, refDate.AddDays(-15), refDate, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Daily, TickType.OpenInterest, refDate.AddDays(-15), refDate, true);
 
                 // invalid resolution, null result
-                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, now.AddSeconds(-15), now, true);
-                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, now.Add(-Time.OneMinute), now, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Tick, TickType.Trade, refDate.AddSeconds(-15), refDate, true);
+                yield return new TestCaseData(BTCUSD, Resolution.Second, TickType.Trade, refDate.Add(-Time.OneMinute), refDate, true);
 
                 // invalid symbol, null result
-                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, now.AddDays(-15), now, true);
+                yield return new TestCaseData(Symbol.Create("ABCXYZ", SecurityType.Crypto, Market.Coinbase), Resolution.Daily, TickType.Trade, refDate.AddDays(-15), refDate, true);
 
                 // invalid security type, null result
-                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, now.AddDays(-15), now, true);
+                yield return new TestCaseData(Symbols.EURGBP, Resolution.Daily, TickType.Trade, refDate.AddDays(-15), refDate, true);
 
                 // invalid market, null result
-                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, now.AddDays(-15), now, true);
+                yield return new TestCaseData(Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Binance), Resolution.Daily, TickType.Trade, refDate.AddDays(-15), refDate, true);
             }
         }
     }

--- a/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.HistoryProvider.cs
+++ b/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.HistoryProvider.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Brokerages.Coinbase
                         // Note from Coinbase docs:
                         // If data points are readily available, your response may contain as many as 300 candles
                         // and some of those candles may precede your declared start value.
-                        yield break;
+                        continue;
                     }
 
                     var tradeBar = new TradeBar(

--- a/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.HistoryProvider.cs
+++ b/QuantConnect.CoinbaseBrokerage/CoinbaseBrokerage.HistoryProvider.cs
@@ -132,7 +132,7 @@ namespace QuantConnect.Brokerages.Coinbase
                         // Note from Coinbase docs:
                         // If data points are readily available, your response may contain as many as 300 candles
                         // and some of those candles may precede your declared start value.
-                        continue;
+                        yield break;
                     }
 
                     var tradeBar = new TradeBar(
@@ -150,7 +150,9 @@ namespace QuantConnect.Brokerages.Coinbase
                     yield return tradeBar;
                 }
 
-                startTime = lastTradeBar?.EndTime ?? request.EndTimeUtc;
+                // Advance by the batch window when no candles are returned (e.g. start date predates
+                // the asset listing), instead of jumping to EndTimeUtc and silently returning nothing.
+                startTime = lastTradeBar?.EndTime ?? endTime;
                 endTime = request.EndTimeUtc;
             } while (startTime < request.EndTimeUtc);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The Coinbase API fetches history in 300 candle batches. When a batch came back empty, `startTime` jumped to `request.EndTimeUtc`, killing the loop and returning nothing. Now it advances to the end of the empty batch instead, iterating until data is found.

#### Related Issue
Closes LEAN [8993](https://github.com/QuantConnect/Lean/issues/8993)

#### Motivation and Context
N/A

#### Requires Documentation Change
N/A

#### How Has This Been Tested?
It was tested using unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
